### PR TITLE
added fix for timestamp_utc block conditions

### DIFF
--- a/cspr_summarization/services/lp_hourly_summarizer/lp_hourly_summarizer.py
+++ b/cspr_summarization/services/lp_hourly_summarizer/lp_hourly_summarizer.py
@@ -25,9 +25,9 @@ class LpHourlySummarizer:
     self.start_hour = start_hour
     self.end_hour = end_hour
     # Fetch the last hour blocks
-    blocks = BlockHours.objects \
-      .filter(hourly_timestamp_utc__range=(self.start_hour, self.end_hour)) \
-      .values('block_number', 'hourly_timestamp_utc').order_by('-hourly_timestamp_utc')
+    blocks = Blocks.objects \
+      .filter(timestamp_utc__gte=self.start_hour, timestamp_utc__lt= self.end_hour) \
+      .values('block_number', 'timestamp_utc').order_by('-timestamp_utc')
     self.last_hour_block_numbers = pd.DataFrame.from_records(blocks)
     all_pairs = AllPairs.objects.values('id', 'contract_address', 'token0_decimals', 'token1_decimals', 'token0_address', 'token1_address')
     self.all_pairs = pd.DataFrame.from_records(all_pairs)

--- a/hourly_summarizer.py
+++ b/hourly_summarizer.py
@@ -32,6 +32,7 @@ def run_hourly_summarizer(start_hour_param = None):
       # then get the min hourly data timestamp (from BlockHours)
       except:
         last_end_hour = BlockHours.objects.values('hourly_timestamp_utc').order_by('hourly_timestamp_utc').first()['hourly_timestamp_utc']
+        last_end_hour = last_end_hour - timedelta(hours=1)
     except:
       logging.warning('❌ The service could not be started Please populate BlockHours data before running the service as no data was found on the BlockHours table')
       return
@@ -52,11 +53,11 @@ def run_hourly_summarizer(start_hour_param = None):
     last_hourly_block_timestamp = next_start_hour - timedelta(hours=1)
 
   # Already summarized data for this hour 
-  if (next_start_hour > last_hourly_block_timestamp) and (not forced_to_run):
+  if (next_start_hour >= last_hourly_block_timestamp) and (not forced_to_run):
     logging.info(f'✅ Hourly Summarization has already been run for the time range: {next_start_hour} - {next_end_hour}')
 
   # While not done with all the missed past hours Do ...
-  while (last_hourly_block_timestamp >= next_start_hour) or (forced_to_run):
+  while (last_hourly_block_timestamp > next_start_hour) or (forced_to_run):
 
     summarizer = LpHourlySummarizer(next_start_hour, next_end_hour)
     # Initilize Data (all column at 0)


### PR DESCRIPTION
### Description
Quick fix on the way we getting the blocks. 

### Changes
- Now we're getting the blocks range from the Blocks table.
- The condition used is no longer the `between` but used `greater than or equal` and `less than` (to exclude the `end_hour` from the range).


